### PR TITLE
Fixed UI: added scrollbar to admin category list

### DIFF
--- a/Web/ratings.js
+++ b/Web/ratings.js
@@ -6624,9 +6624,8 @@
 
                 .admin-category-list {
                     padding: 8px !important;
-                    display: flex !important;
-                    flex-direction: column !important;
-                    gap: 4px !important;
+		    max-height: 400px !important
+		    overflow-y: auto !important
                 }
 
                 /* Category Colors */


### PR DESCRIPTION
I use this feature of your plugin to save and see which movies i need to download / did download etc... I found it annoying that there isn't a scrollbar when bunch of movies are in one section. I added scrollbar to it without changing the look of the window.

Before: <img width="957" height="853" alt="image" src="https://github.com/user-attachments/assets/405e0540-1d45-46a8-8427-140421af303d" />


After: 
<img width="962" height="859" alt="image" src="https://github.com/user-attachments/assets/4ff96456-b559-4fda-962f-ae26679f4972" />

You can change the max-height to something you would like i just put 400 for convenience sake