### PR TITLE
fix: fixed category list scroll behavior

### DIFF
--- a/Web/ratings.css
+++ b/Web/ratings.css
@@ -2253,9 +2253,6 @@ body.ratings-no-card-overlay .netflix-card.has-rating::after {
 
 .admin-category-list {
     padding: 8px !important;
-    display: flex !important;
-    flex-direction: column !important;
-    gap: 4px !important;
     /* Long category lists get their own scrollbar instead of overflowing the modal (PR #73). */
     max-height: 400px !important;
     overflow-y: auto !important;

--- a/Web/ratings.css
+++ b/Web/ratings.css
@@ -2253,8 +2253,11 @@ body.ratings-no-card-overlay .netflix-card.has-rating::after {
 
 .admin-category-list {
     padding: 8px !important;
+    display: flex !important;
+    flex-direction: column !important
+    gap: 4px !important;
     /* Long category lists get their own scrollbar instead of overflowing the modal (PR #73). */
-    max-height: 400px !important;
+    max-height: 500px !important;
     overflow-y: auto !important;
 }
 
@@ -2322,6 +2325,7 @@ body.ratings-no-card-overlay .netflix-card.has-rating::after {
     cursor: pointer !important;
     transition: all 0.2s ease !important;
     overflow: hidden !important;
+    flex-shrink: 0 !important;
 }
 
 .admin-request-item:hover {


### PR DESCRIPTION
Deleted lines of code that make the movies in a list look like this.

<img width="958" height="923" alt="issue" src="https://github.com/user-attachments/assets/b968da6a-7e10-4c36-b879-eb054102c01e" />


Now it should look like this

<img width="960" height="990" alt="fix" src="https://github.com/user-attachments/assets/acaee4d9-2665-4c08-8ec3-8690c60de9b9" />
