### PR TITLE
fix(mobile): improve admin request compact layout

### DIFF
--- a/Web/ratings.css
+++ b/Web/ratings.css
@@ -11223,3 +11223,71 @@ body:has(.videoPlayerContainer) #ratingsMenuToggle {
     color: #fff;
     text-decoration-color: rgba(0, 224, 84, 0.6);
 }
+
+@media screen and (max-width: 768px) {
+    /* 1. Compact request item row layout */
+    .admin-request-compact {
+        flex-wrap: wrap !important;
+        align-items: center !important;
+        padding-top: 4px !important;
+        padding-bottom: 4px !important;
+        padding-left: 8px !important;
+        padding-right: 8px !important;
+    }
+
+    /* 2. Force full-width visible movie/show title at the top */
+    .admin-request-compact-title {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        flex: 1 0 100% !important;
+        width: 100% !important;
+        margin-top: -2px !important;
+        margin-bottom: 2px !important;
+        line-height: 1.2 !important;
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+    }
+
+    /* 3. Keep meta tags (user, date, status button) cleanly aligned below title */
+    .admin-request-compact-meta {
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        align-items: center !important;
+        width: 100% !important;
+        margin-top: 0 !important;
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+    }
+
+    /* 4. Pin the dropdown expand arrow to the right edge */
+    .admin-request-expand-icon {
+        display: inline-block !important;
+        visibility: visible !important;
+        margin-left: auto !important;
+    }
+
+    /* 5. Stack action inputs (Media & Rejection reason) vertically */
+    .admin-request-compact-expanded,
+    .admin-request-details,
+    div:has(> input[placeholder*="Media"]),
+    div:has(> input[placeholder*="Rejection"]) {
+        display: flex !important;
+        flex-direction: column !important;
+        width: 100% !important;
+        gap: 8px !important;
+    }
+
+    /* 6. Expand input fields to 100% width so text is never cut off */
+    input[placeholder*="Media"],
+    input[placeholder*="Rejection"],
+    .admin-request-compact-expanded input {
+        width: 100% !important;
+        max-width: 100% !important;
+        box-sizing: border-box !important;
+    }
+}


### PR DESCRIPTION
Fixed the issue on mobile (browser and i think these will translate to app as well). Here is how admin categories looked before 

<img width="1045" height="972" alt="issue 1" src="https://github.com/user-attachments/assets/3dc57dee-1754-4c6f-8ed0-645ec3b06f77" />

Expanded:

<img width="892" height="955" alt="issue 2 expanded" src="https://github.com/user-attachments/assets/3dba0b9c-3844-4fd2-a53a-2d73d65ee602" />


And here it is how it looks now

<img width="1917" height="993" alt="fixed 1" src="https://github.com/user-attachments/assets/fb1989ae-225a-49c5-a2f5-548def80c2f6" />

Expanded:

<img width="1916" height="990" alt="fixed 2 expanded" src="https://github.com/user-attachments/assets/f37411da-3b0b-43d1-b13e-fa6f33abcdce" />

What had been done: name not showing on mobile when collapsed, When expanded media link input box is now moved up instead of next to rejection reason input box so it doesn't collapse.

I just put my code at the bottom of your code bcs i don't know where else to put it bcs its in @media. if you want you can tell me where to put it or just leave it like that.